### PR TITLE
Add Proxy video setting to proxy video when video fails to play

### DIFF
--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -107,6 +107,12 @@ class Dispatcher(object):
         if mime:
             item.setMimeType(mime)
             item.setContentLookup(False)
+
+        is_proxy_video = getSetting("proxy_video", _type=bool)
+
+        if is_proxy_video:
+            item.setPath(item.getPath() + "?local=true")
+
         xbmcplugin.setResolvedUrl(self.handle, True, item)
         return True
 


### PR DESCRIPTION
We use Invidious because we want to avoid youtube.

So why bother to youtube plugin when the video fails to play?

After add `?local=true` query parameter to the end of url

We can now watch the video that fails to play && degoogle.
