### PR TITLE
add import newpipe subscriptions to plugin feed

### DIFF
--- a/lib/invidious/persistence.py
+++ b/lib/invidious/persistence.py
@@ -20,6 +20,10 @@ class ChannelFeed(Persistent, OrderedDict):
         for key in keys:
             del self[key]
 
+    @save
+    def removeAll(self):
+        self.clear()
+
 
 channel_feed = ChannelFeed()
 

--- a/lib/invidious/persistence.py
+++ b/lib/invidious/persistence.py
@@ -22,7 +22,7 @@ class ChannelFeed(Persistent, OrderedDict):
 
     @save
     def clear(self):
-        super().clear()
+        super(ChannelFeed, self).clear()
 
 
 channel_feed = ChannelFeed()

--- a/lib/invidious/persistence.py
+++ b/lib/invidious/persistence.py
@@ -21,8 +21,8 @@ class ChannelFeed(Persistent, OrderedDict):
             del self[key]
 
     @save
-    def removeAll(self):
-        self.clear()
+    def clear(self):
+        super().clear()
 
 
 channel_feed = ChannelFeed()

--- a/lib/script.py
+++ b/lib/script.py
@@ -96,7 +96,7 @@ def newpipeImport():
     with open(newpipe_filepath, 'r', encoding='utf-8') as fp:
         newpipe_dict = json.load(fp)
         newpipe_subscriptions = newpipe_dict.get('subscriptions', ())
-        channel_feed.removeAll()
+        channel_feed.clear()
         for item in newpipe_subscriptions:
             item_id = item['url'].split('/')[-1]
             channel_feed.add(item_id, item['name'])

--- a/lib/script.py
+++ b/lib/script.py
@@ -3,6 +3,7 @@
 
 from sys import argv
 from urllib.parse import unquote_plus
+import json
 
 from iapc.tools import (
     getAddonId, selectDialog, getSetting, setSetting,
@@ -89,6 +90,18 @@ def removeChannelsFromFeed():
         channel_feed.remove(*(keys[index] for index in indices))
 
 
+def newpipeImport():
+    newpipe_filepath = getSetting("newpipe.path")
+
+    with open(newpipe_filepath, 'r', encoding='utf-8') as fp:
+        newpipe_dict = json.load(fp)
+        newpipe_subscriptions = newpipe_dict.get('subscriptions', ())
+        channel_feed.removeAll()
+        for item in newpipe_subscriptions:
+            item_id = item['url'].split('/')[-1]
+            channel_feed.add(item_id, item['name'])
+
+
 # __main__ ---------------------------------------------------------------------
 
 __dispatch__ = {
@@ -100,6 +113,7 @@ __dispatch__ = {
     "selectLocation": selectLocation,
     "addChannelToFeed": addChannelToFeed,
     "removeChannelsFromFeed": removeChannelsFromFeed,
+    "newpipeImport": newpipeImport,
     "removeSearchQuery": removeSearchQuery,
     "clearSearchHistory": clearSearchHistory,
     "updateSortBy": updateSortBy

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -270,3 +270,15 @@ msgctxt "#30135"
 msgid "Always ask"
 msgstr ""
 
+msgctxt "#30136"
+msgid "Feed: Newpipe Subscriptions"
+msgstr ""
+
+msgctxt "#30137"
+msgid "Subscriptions path"
+msgstr ""
+
+
+msgctxt "#30138"
+msgid "Import feed"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -278,7 +278,7 @@ msgctxt "#30137"
 msgid "Subscriptions path"
 msgstr ""
 
-
 msgctxt "#30138"
 msgid "Import feed"
 msgstr ""
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -198,6 +198,32 @@
 
             </group>
 
+
+            <!-- Newpipe -->
+            <group id="newpipe" label="30136">
+                <setting id="newpipe.path" label="30137" type="path">
+                    <level>0</level>
+                    <default></default>
+                    <constraints>
+                        <writable>false</writable>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="button" format="file">
+                        <heading>30137</heading>
+                    </control>
+                </setting>
+
+                <setting id="newpipe.import" label="30138" type="action" parent="newpipe.path">
+                    <level>0</level>
+                    <data>RunScript($ID,newpipeImport)</data>
+                    <dependencies>
+                        <dependency type="enable" setting="newpipe.path" operator="!is"></dependency>
+                    </dependencies>
+                    <control type="button" format="action" />
+                </setting>
+
+            </group>
+
             <!-- Search history -->
             <group id="search_history" label="30115">
 


### PR DESCRIPTION
**Condition:**
- i have more than 50 channel subscriptions on youtube
- "Export to RSS readers" on  https://www.youtube.com/subscription_manager is not working
- i have move these channel subscriptions to newpipe subscriptions file (newpipe-subcriptions.json)

**Expected:**
- i want to follow these youtube subscriptions via the plugin feed

**Actual:**
- it is hardwork to add youtube channel subscriptions to plugin feed one by one. especially when you have more than 20
- there is no way to import newpipe-subcriptions.json via plugin settings

**Known Issue:**
i have to save `subscription path` to settings.xml by click `ok` first before i can run `import to feed`.
ideally i want `import feed` after i set `subscription path` without click `ok` first

**Reference:**
- https://github.com/lekma/plugin.video.invidious/issues/53
- https://newpipe.net/FAQ/tutorials/import-export-data/

**Tips**
convert youtube channel to newpipe-subcriptions.json

- open https://www.youtube.com/feed/channels
- login to your account
- open web console. see [firefox](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html), [chromium](https://developer.chrome.com/docs/devtools/open/#console)
- copy paste this snippet
    ```js
    ytContents = ytInitialData.contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents;
    window.prompt(
        'CTRL+A, CTRL+C',
        JSON.stringify({
            "app_version": "0.19.8", "app_version_int": 953,
            'subscriptions': ytContents[0].itemSectionRenderer.contents[0].shelfRenderer.content.expandedShelfContentsRenderer.items.map(item => ({
                'service_id': 0,
                'url': `https://www.youtube.com/channel/${item.channelRenderer.channelId}`,
                'name': item.channelRenderer.title.simpleText
            }))
        })
    )
    ```
- copy dialog content and past to new file named newpipe-subcriptions.json
