### PR TITLE
fix: remove instances with api disabled

### DIFF
--- a/lib/invidious/client.py
+++ b/lib/invidious/client.py
@@ -54,7 +54,7 @@ class InvidiousClient(object):
     def instances(self, **kwargs):
         return [
             instance[0] for instance in self.__client__.instances(**kwargs)
-            if instance[1]["type"] in ("http", "https")
+            if instance[1]["type"] in ("http", "https") and instance[1]["api"]
         ]
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
Each instance has an `api` field associated with it, if this is set to false, then it will not work in third-party clients such as this one.

All requests will just result in a 403 (Forbidden).

This removes those instances from the instance selection.

![image](https://user-images.githubusercontent.com/22801583/234986386-d7af6e4e-9588-4dfb-b589-d1a8809be6a8.png)

