### PR TITLE
perf: multi thread feed requests

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.invidious"
        name="Invidious"
-       version="2.1.1"
+       version="2.2.0"
        provider-name="lekma">
 
     <requires>


### PR DESCRIPTION
On my [RockPro64](https://www.pine64.org/rockpro64/), the feed was loading very slowly. With 26 subscriptions, it was taking somewhere between 20 and 60 seconds.

This throws in a [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor) to add concurrency. Unfortunately, it's just threads, I'm uncertain if it's possible to utilize the benefits of asyncio on Kodi. [[reference]](https://kodi.wiki/view/Python_Problems#asyncio)

However, with this, updating the feed is closer to 6-15 seconds~ on my device. :+1: 

Please refer to my docstrings for more details on:
* Why I'm using threads instead of [asyncio](https://docs.python.org/3/library/asyncio.html).
* Why I'm creating an instance of `InvidiousSession` per thread instead of a singleton.

### Notes

* If the system only 2 or less core/thread, or we're unable to determine how many threads it has, we do a synchronous loop like before.