### PR TITLE
ux: move search to top

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.invidious"
        name="Invidious"
-       version="2.2.0"
+       version="2.2.1"
        provider-name="lekma">
 
     <requires>

--- a/lib/invidious/search.py
+++ b/lib/invidious/search.py
@@ -22,31 +22,31 @@ def sortBy(sort_by="relevance"):
     return sort_by
 
 
-def newSearch(type, sort_by=None, history=False):
+def newSearch(search_type, sort_by=None, history=False):
     if (query := inputDialog(heading=30002)):
         if sort_by is None:
             sort_by = sortBy()
         if history:
-            search_history.record(type, query, sort_by)
+            search_history.record(search_type, query, sort_by)
     return (query, sort_by)
 
 
-def searchHistory(type):
+def searchHistory(search_type):
     return Queries(
-        reversed(search_history[type].values()), category=queryTypes[type]
+        reversed(search_history[search_type].values()), category=queryTypes[search_type]
     )
 
 
-def removeSearchQuery(type, query):
-    search_history.remove(type, query)
+def removeSearchQuery(search_type, query):
+    search_history.remove(search_type, query)
     containerRefresh()
 
 
 __search_url__ = f"plugin://{getAddonId()}/?action=search"
 
-def clearSearchHistory(type=None, update=False):
-    search_history.clear(type=type)
-    if type:
+def clearSearchHistory(search_type=None, update=False):
+    search_history.clear(search_type=search_type)
+    if search_type:
         containerRefresh()
     else:
         notify(30114, time=2000)
@@ -56,8 +56,7 @@ def clearSearchHistory(type=None, update=False):
             containerRefresh()
 
 
-def updateSortBy(type, query, _sort_by_):
+def updateSortBy(search_type, query, _sort_by_):
     if ((sort_by := sortBy(sort_by=_sort_by_)) != _sort_by_):
-        search_history.record(type, query, sort_by)
+        search_history.record(search_type, query, sort_by)
         containerRefresh()
-

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -11,7 +11,7 @@ from iapc.tools import Plugin, action, parseQuery, openSettings, getSetting
 from invidious import home, styles, sortBy
 from invidious.client import client
 from invidious.objects import Folders
-from invidious.persistence import channel_feed, search_cache
+from invidious.persistence import channel_feed, search_cache, search_history
 from invidious.search import newSearch, searchHistory
 from invidious.utils import moreItem, newSearchItem, playlistsItem, settingsItem
 
@@ -196,9 +196,12 @@ class InvidiousPlugin(Plugin):
     def search(self, **kwargs):
         history = getSetting("history", bool)
         if "type" in kwargs:
+            search_type = kwargs["type"]
             query = kwargs.pop("query", "")
             new = kwargs.pop("new", False)
             if query:
+                if history and query in search_history[search_type]:
+                    search_history.move_to_end(search_type, query)
                 return self.__search__(query, **kwargs)
             if new:
                 return self.__new_search__(history=history, **kwargs)
@@ -224,4 +227,3 @@ def dispatch(url, handle, query, *args):
 
 if __name__ == "__main__":
     dispatch(*argv)
-


### PR DESCRIPTION
This does a minor UX improvement:

* pressing an old search will bring it back to the top of the search history.
* searching something that was already searched before (i.e. very far down in the list) also brings it back to the top.

### Note

* I changed `SearchHistory` to use `OrderedDict` for persistence, and override `__setitem__` to cast any values to an `OrderedDict` heeding your advice in [script.module.iapc/issues/3](https://github.com/lekma/script.module.iapc/issues/3).
* On the side, I renamed some instances of `type` to `search_type` to avoid shadowing the built-in [`type`](https://docs.python.org/3/library/functions.html#type) function. I was using this while trying to figure out why `#move_to_end` wasn't working, but the shadowing was getting in the way.

### Related

* Implementation impacted by https://github.com/lekma/script.module.iapc/issues/3#issue-1740654152