### PR TITLE
chore: add country to server list

### DIFF
--- a/lib/invidious/client.py
+++ b/lib/invidious/client.py
@@ -53,7 +53,7 @@ class InvidiousClient(object):
 
     def instances(self, **kwargs):
         return [
-            instance[0] for instance in self.__client__.instances(**kwargs)
+            instance for instance in self.__client__.instances(**kwargs)
             if (
                 (instance[1]["type"] in ("http", "https")) and
                 instance[1]["api"]

--- a/lib/script.py
+++ b/lib/script.py
@@ -57,10 +57,16 @@ def selectInstance():
     instance = getSetting("instance", str)
     instances = client.instances(sort_by="health")
     if instances:
-        preselect = instances.index(instance) if instance in instances else -1
-        index = selectDialog(instances, heading=30105, preselect=preselect)
+        urls, lines = [], []
+
+        for iter in instances:
+            urls.append(iter[0])
+            lines.append(f"{iter[0]} ({iter[1]['region']})")
+
+        preselect = urls.index(instance) if instance in urls else -1
+        index = selectDialog(lines, heading=30105, preselect=preselect)
         if index >= 0:
-            setSetting("instance", instances[index], str)
+            setSetting("instance", urls[index], str)
 
 
 # selectLanguage ---------------------------------------------------------------

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -198,6 +198,10 @@ msgctxt "#30107"
 msgid "Instance"
 msgstr ""
 
+msgctxt "#30110"
+msgid "Displays a list of public instances, along with the region the server is hosted in. Selecting one will update the \"Instance name/ip address\" setting."
+msgstr ""
+
 msgctxt "#30111"
 msgid "Persistent data"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,7 +10,7 @@
             <!-- Instance -->
             <group id="instance" label="30107">
 
-                <setting id="selectInstance" label="30105" type="action">
+                <setting id="selectInstance" type="action" label="30105" help="30110">
                     <level>0</level>
                     <data>RunScript($ID,selectInstance)</data>
                     <control type="button" format="action" />


### PR DESCRIPTION
Adds the region of an instance in brackets in the public server list.

Sometimes an instance takes too long to respond, or is just overloaded. When this happens, the user has to switch instance, so it helps set out some criteria to aid the user in choosing one.

Normally, I think showing latency next to each server would be best, but it's not ideal to ping or hit `GET /stats` on each public instance without the user's permission. Plus, it'd make loading the instances list even slower, which would make for a shoddy UX.

As an alternative, since we already have the region information available, we can just display that next to the server name. I already check this personally when picking an instance, so it'll be very convenient to have this information available inside the addon.

I prefer to use instances in Europe, for example, and usually get the best latency to instances in Germany (DE) or Finland (FI).

I did consider using the region's flag instead, but unfortunately not all skins/themes will display them, including mine, which is the default.

### Screenshots

![image](https://github.com/lekma/plugin.video.invidious/assets/22801583/760280b8-79c7-4b12-b727-1b423901cb20)
> See the help text in blue at the bottom.

![image](https://github.com/lekma/plugin.video.invidious/assets/22801583/76ba4d3d-5882-4c41-80ac-fa89d8fb6670)
> See how in brackets after each instance name, it shows the region in brackets.

--- 

PS: Ignore the **Auto-select instance** setting, that's just me working on adding auto-selecting servers, but that'll take me some time, so figured I'd PR this already.