### PR TITLE
chore: remove infolabels from settings

### DIFF
--- a/lib/invidious/utils.py
+++ b/lib/invidious/utils.py
@@ -13,7 +13,6 @@ def __makeItem__(label, url, art=None, isFolder=True, **kwargs):
         buildUrl(url, **kwargs),
         isFolder=isFolder,
         isPlayable=False,
-        infoLabels={"video": {"title": label, "plot": label}},
         poster=art,
         icon=art
     )
@@ -41,4 +40,3 @@ def newSearchItem(url, **kwargs):
 # playlists item
 def playlistsItem(url, **kwargs):
     return __makeItem__(30005, url, "DefaultPlaylist.png", **kwargs)
-


### PR DESCRIPTION
Before when opening the context menu on the settings, it would show "Mark as watched".

I'm not sure why `infoLabels` were applied to these non-video menu items, but I don't think they need to be there, do they?

This change stops Kodi from offering to mark **Settings** as watched.