### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+curly_bracket_next_line = false
+spaces_around_operators = true
+
+[*.{xml,py}]
+indent_size = 4
+
+[*.{markdown,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Sorry for the petty PR, mind if this is included? ^-^'
Adds an [EditorConfig](https://editorconfig.org/) file to the repository.

It just makes it a bit easier to contribute since the project can define the conventions. In my editor, I use different settings from what you're doing.

TL;DR: EditorConfig is an editor/vendor-agnostic configuration file to manage project conventions. Most editors support automatically adjusting the settings when the file is found.